### PR TITLE
Rediseñar panel lateral de capas

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,7 @@
   <link href="src/js/components/about/about.css" rel="stylesheet">
   <link href="src/js/components/login/login.css" rel="stylesheet">
   <link rel="stylesheet" href="src/js/components/table/table.css">
+  <link rel="stylesheet" href="src/styles/css/layer-panel.css">
 
 </head>
 

--- a/src/js/entities.js
+++ b/src/js/entities.js
@@ -103,8 +103,6 @@ class ImpresorItemHTML extends Impresor {
   imprimir(item) {
     var childId = item.getId();
     let lyr = item.capa,
-      legend,
-      legendParams = _LEGEND_PARAMS + _LEGEND_OPTIONS + "forceTitles:off;forceLabels:off;",
       aux = {
         ...item,
         childid: childId,
@@ -114,100 +112,154 @@ class ImpresorItemHTML extends Impresor {
     app.setLayer(aux);
     app.layerNameByDomId[childId] = item.nombre;
 
-    if (
-      lyr.legendURL === null ||
-      typeof lyr.legendURL === "undefined" ||
-      lyr.legendURL === ""
-    ) {
-      if (lyr.servicio === "wms") {
-        lyr.legendURL =
-          lyr.host +
-          "?service=WMS&request=GetLegendGraphic&format=image%2Fpng&version=1.1.1&layer=" +
-          lyr.nombre;
-      } else {
-        lyr.legendURL = item.legendImg || ERROR_IMG;
-      }
-    }
-    legend = lyr.legendURL.includes("GetLegendGraphic")
-      ? lyr.legendURL + legendParams
-      : lyr.legendURL;
-
-    // following line adds layer when click is made
-    let legendImg = `<div class='legend-layer'><img class='legend-img' style='width:20px;height:20px' loading='lazy' src='${legend}' onerror='showImageOnError(this);' onload='adaptToImage(this.parentNode)'></div>`;
-    let activated = item.visible == true ? " active " : "",
-      btnhtml = "";
+    const layerTitle = item.titulo
+      ? item.titulo.replace(/_/g, " ")
+      : "por favor ingrese un nombre";
+    const layerDescription = item.descripcion || layerTitle;
+    const activated = item.visible == true ? " active layer-active" : "";
 
     const btn = document.createElement("li");
     btn.id = childId;
-    btn.classList = "capa list-group-item" + activated;
-    btn.style.padding = "10px 1px 10px 1px";
+    btn.className = "capa list-group-item layer-row" + activated;
+    btn.setAttribute("data-layer-name", item.nombre);
 
-    const btn_title = document.createElement("div");
-    btn_title.className = "capa-title";
-    btn_title.innerHTML = legendImg;
+    const legendWrapper = document.createElement("div");
+    legendWrapper.className = "legend-layer layer-legend";
+    const legendImg = document.createElement("img");
+    legendImg.className = "legend-img";
+    legendImg.loading = "lazy";
+    legendImg.alt = "";
+    legendImg.src = buildLayerLegendUrl(lyr, item.legendImg);
+    legendImg.onerror = function () {
+      showImageOnError(this);
+    };
+    legendImg.onload = function () {
+      adaptToImage(this.parentNode);
+    };
+    legendWrapper.appendChild(legendImg);
 
-    const btn_name = document.createElement("div");
-    btn_name.className = "name-layer";
+    const btn_name = document.createElement("button");
+    btn_name.type = "button";
+    btn_name.className = "name-layer layer-name";
+    btn_name.setAttribute("nombre", item.nombre);
+    btn_name.setAttribute("title", layerTitle);
+    btn_name.setAttribute("aria-label", "Activar o desactivar capa " + layerTitle);
     btn_name.setAttribute("onClick", `gestorMenu.muestraCapa(\'${childId}\')`);
-    btn_name.style.alignSelf = "center";
-
-    const btn_link = document.createElement("a");
-    btn_link.setAttribute("nombre", item.nombre);
-    btn_link.href = "#";
 
     const btn_tooltip = document.createElement("span");
     btn_tooltip.setAttribute("data-toggle2", "tooltip");
-    btn_tooltip.title = item.descripcion;
-    btn_tooltip.innerHTML = item.titulo
-      ? item.titulo.replace(/_/g, " ")
-      : "por favor ingrese un nombre";
+    btn_tooltip.title = layerDescription;
+    btn_tooltip.textContent = layerTitle;
+    btn_name.appendChild(btn_tooltip);
 
-    const btn_zoom = document.createElement("div");
-    btn_zoom.className = "zoom-layer";
+    const btn_zoom = document.createElement("button");
+    btn_zoom.type = "button";
+    btn_zoom.className = "zoom-layer layer-zoom";
     btn_zoom.setAttribute("layername", item.nombre);
-    btn_zoom.style.alignSelf = "center";
+    btn_zoom.setAttribute("aria-label", "Zoom a capa " + layerTitle);
+    btn_zoom.title = "Zoom a capa";
 
     const btn_zoom_icon = document.createElement("i");
-    btn_zoom_icon.classList = "fas fa-search-plus";
-    btn_zoom_icon.title = "Zoom a capa";
+    btn_zoom_icon.className = "fas fa-search-plus";
+    btn_zoom_icon.setAttribute("aria-hidden", "true");
+    btn_zoom.appendChild(btn_zoom_icon);
 
-    const btn_options_icon_div = document.createElement("div");
+    const visibilityIndicator = document.createElement("span");
+    visibilityIndicator.className = "layer-visibility-indicator";
+    visibilityIndicator.setAttribute("aria-hidden", "true");
+    btn_name.appendChild(visibilityIndicator);
+
+    const btn_options_icon_div = document.createElement("button");
+    btn_options_icon_div.type = "button";
     btn_options_icon_div.className = "layer-options-icon";
     btn_options_icon_div.setAttribute("layername", item.nombre);
     btn_options_icon_div.title = "Opciones";
+    btn_options_icon_div.setAttribute("aria-label", "Opciones de capa " + layerTitle);
 
     const btn_options_icon = document.createElement("i");
-    btn_options_icon.classList = "fas fa-angle-down";
-    btn_options_icon.title = "Zoom a capa";
-
-    const btn_options_list = document.createElement("div");
-    btn_options_list.className = "display-none";
-    btn_options_list.id = "layer-options-" + item.nombre;
+    btn_options_icon.className = "fas fa-angle-down";
+    btn_options_icon.setAttribute("aria-hidden", "true");
 
     const btn_options = document.createElement("div");
     btn_options.className = "display-none";
     btn_options.id = "layer-options-" + item.nombre;
 
     if (loadLayerOptions) {
-      btn.style.padding = "10px 1px 1px 1px";
-      btn_name.removeAttribute("style");
-      btn_zoom.removeAttribute("style");
+      btn.classList.add("layer-row-with-options");
       btn_options_icon_div.appendChild(btn_options_icon);
     }
 
-    btn_link.appendChild(btn_tooltip);
-    btn_name.appendChild(btn_link);
-    btn_title.appendChild(btn_name);
-
-    btn_zoom.appendChild(btn_zoom_icon);
-    btn_title.appendChild(btn_zoom);
-
-    btn.appendChild(btn_title);
-    btn.appendChild(btn_options_icon_div);
+    btn.appendChild(legendWrapper);
+    btn.appendChild(btn_name);
+    btn.appendChild(btn_zoom);
+    if (loadLayerOptions) {
+      btn.appendChild(btn_options_icon_div);
+    }
     btn.appendChild(btn_options);
 
     return btn.outerHTML;
   }
+}
+
+function buildLayerLegendUrl(layer, fallbackLegend) {
+  if (!layer) {
+    return fallbackLegend || ERROR_IMG;
+  }
+
+  if (layer.legendURL) {
+    return ensureSecureLegendUrl(layer.legendURL.includes("GetLegendGraphic")
+      ? layer.legendURL + _LEGEND_PARAMS + _LEGEND_OPTIONS + "forceTitles:off;forceLabels:off;"
+      : layer.legendURL);
+  }
+
+  if (layer.servicio === "wms" && layer.host) {
+    const url = new URL(layer.host, window.location.origin);
+    const workspace = getGeoserverWorkspace(url, layer.nombre);
+    if (workspace) {
+      const parts = url.pathname.split("/").filter(Boolean);
+      const geoserverIndex = parts.indexOf("geoserver");
+      if (geoserverIndex >= 0) {
+        url.pathname = "/" + parts.slice(0, geoserverIndex + 1).concat([workspace, "wms"]).join("/");
+      }
+    }
+    url.search = "";
+    const layerName = layer.nombre.includes(":") || !workspace ? layer.nombre : workspace + ":" + layer.nombre;
+    url.searchParams.set("service", "WMS");
+    url.searchParams.set("version", "1.1.0");
+    url.searchParams.set("request", "GetLegendGraphic");
+    url.searchParams.set("format", "image/png");
+    url.searchParams.set("width", "20");
+    url.searchParams.set("height", "20");
+    url.searchParams.set("layer", layerName);
+    url.searchParams.set("transparent", "true");
+    url.searchParams.set("LEGEND_OPTIONS", "forceTitles:off;forceLabels:off;fontAntiAliasing:true;hideEmptyRules:true");
+    return ensureSecureLegendUrl(url.toString());
+  }
+
+  return fallbackLegend || ERROR_IMG;
+}
+
+function getGeoserverWorkspace(url, layerName) {
+  const prefixedLayer = layerName && layerName.includes(":") ? layerName.split(":")[0] : null;
+  if (prefixedLayer) {
+    return prefixedLayer;
+  }
+  const parts = url.pathname.split("/").filter(Boolean);
+  const geoserverIndex = parts.indexOf("geoserver");
+  if (geoserverIndex >= 0 && parts[geoserverIndex + 1] && parts[geoserverIndex + 1] !== "wms") {
+    return parts[geoserverIndex + 1];
+  }
+  return null;
+}
+
+function ensureSecureLegendUrl(url) {
+  if (!url || typeof url !== "string") {
+    return ERROR_IMG;
+  }
+  if (url.startsWith("http://")) {
+    return url.replace("http://", "https://");
+  }
+  return url;
 }
 
 class ImpresorItemWMSSelector extends Impresor {
@@ -407,47 +459,58 @@ class ImpresorItemCapaBaseHTML extends Impresor {
 class ImpresorGrupoHTML extends Impresor {
   imprimir(itemComposite) {
     var listaId = itemComposite.getId();
-    var itemClass = "menu5";
-    let seccion = itemComposite.seccion;
-
     var active = itemComposite.getActive() == true ? " in " : "";
+    var expanded = itemComposite.getActive() == true ? "true" : "false";
+    var titleId = listaId + "-title";
+    var groupDescription = escapeHtmlAttribute(itemComposite.descripcion || "");
 
     return (
-      '<div id="' +
+      '<section id="' +
       listaId +
-      '" class="' +
-      itemClass +
-      ' panel-default">' +
-      '<div class="panel-heading">' +
-      '<h4 class="panel-title">' +
-      '<a id="' +
+      '" class="menu5 panel-default layer-group">' +
+      '<button id="' +
       listaId +
-      '-a" data-toggle="collapse" data-parent="#accordion1" href="#' +
+      '-a" type="button" class="layer-group-header" data-toggle="collapse" data-target="#' +
       itemComposite.seccion +
-      '" class="item-group-title">' +
+      '" aria-expanded="' +
+      expanded +
+      '" aria-controls="' +
+      itemComposite.seccion +
+      '">' +
+      '<span class="layer-group-text">' +
+      '<span id="' +
+      titleId +
+      '" class="item-group-title layer-group-title">' +
       itemComposite.nombre +
-      "</a>" +
-      "<div class='item-group-short-desc'><a data-toggle='collapse' data-toggle2='tooltip' title='" +
-      itemComposite.descripcion +
-      "' href='#" +
+      '</span>' +
+      '<span class="item-group-short-desc layer-group-description" data-toggle2="tooltip" title="' +
+      groupDescription +
+      '">' +
+      (itemComposite.shortDesc || "") +
+      '</span>' +
+      '</span>' +
+      '<i class="fas fa-chevron-down layer-group-arrow" aria-hidden="true"></i>' +
+      '</button>' +
+      '<div id="' +
       itemComposite.seccion +
-      "'>" +
-      itemComposite.shortDesc +
-      "</a></div>" +
-      "</h4>" +
-      "</div>" +
-      "<div id='" +
-      itemComposite.seccion +
-      "' class='panel-collapse collapse" +
+      '" class="panel-collapse collapse layer-group-content' +
       active +
-      "'>" +
+      '">' +
       '<div class="panel-body">' +
       itemComposite.itemsStr +
-      "</div>" +
-      "</div>" +
-      "</div>"
+      '</div>' +
+      '</div>' +
+      '</section>'
     );
   }
+}
+
+function escapeHtmlAttribute(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 class ImpresorGroupWMSSelector extends Impresor {
@@ -1627,15 +1690,16 @@ class ItemGroup extends ItemComposite {
 
   muestraCantidadCapasVisibles() {
     var iCapasVisibles = this.getCantidadCapasVisibles();
+    const titleSelector = "#" + this.getId() + "-title";
     if (iCapasVisibles > 0) {
-      $("#" + this.getId() + "-a").html(
+      $(titleSelector).html(
         this.nombre +
         " <span class='active-layers-counter'>" +
         iCapasVisibles +
         "</span>"
       );
     } else {
-      $("#" + this.getId() + "-a").html(this.nombre);
+      $(titleSelector).html(this.nombre);
     }
   }
 
@@ -1848,10 +1912,10 @@ class Item extends ItemComposite {
   }
 
   showHide() {
-    $("#" + this.getId()).toggleClass("active");
+    $("#" + this.getId()).toggleClass("active layer-active");
 
     if (this.seccion.includes("mapasbase0") && !$("#" + this.getId()).hasClass("active")) {
-      $("#" + this.getId()).toggleClass("active");
+      $("#" + this.getId()).toggleClass("active layer-active");
     }//fixes main mapabase active bug by asking if its not activated.
 
     if (typeof this.callback == "string") {

--- a/src/js/utils/functions/functions.js
+++ b/src/js/utils/functions/functions.js
@@ -1079,7 +1079,11 @@ function zoomEditableLayers(layername) {
 
 function bindZoomLayer() {
   let elements = document.getElementsByClassName("zoom-layer");
-  let zoomLayer = async function () {
+  let zoomLayer = async function (event) {
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
 
     let layer_name = this.getAttribute("layername");
     let layer = app.layers[layer_name].capa;
@@ -1140,13 +1144,20 @@ function bindZoomLayer() {
   };
 
   for (let i = 0; i < elements.length; i++) {
-    elements[i].addEventListener("click", zoomLayer, false);
+    if (!elements[i].dataset.zoomBound) {
+      elements[i].addEventListener("click", zoomLayer, false);
+      elements[i].dataset.zoomBound = "true";
+    }
   }
 }
 
 function bindLayerOptions() {
   let elements = document.getElementsByClassName("layer-options-icon");
-  let layerOptions = function () {
+  let layerOptions = function (event) {
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
     let layername = this.getAttribute("layername");
     if (!app.layers[layername].display_options) {
       menu_ui.addLayerOptions(layername);
@@ -1156,7 +1167,10 @@ function bindLayerOptions() {
   };
 
   for (let i = 0; i < elements.length; i++) {
-    elements[i].addEventListener("click", layerOptions, false);
+    if (!elements[i].dataset.optionsBound) {
+      elements[i].addEventListener("click", layerOptions, false);
+      elements[i].dataset.optionsBound = "true";
+    }
   }
 }
 

--- a/src/styles/css/layer-panel.css
+++ b/src/styles/css/layer-panel.css
@@ -1,0 +1,237 @@
+#sidebar-container {
+  width: clamp(320px, 25vw, 380px);
+  max-width: 380px;
+  height: calc(100vh - 50px);
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: #f6f8fb;
+}
+
+#sidebar.nav-sidebar,
+#sidebar.nav {
+  padding: 0;
+}
+
+.layer-group {
+  margin: 0 0 8px;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  background: #fff;
+  overflow: hidden;
+}
+
+.layer-group-header {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 0;
+  border-bottom: 1px solid #e5e7eb;
+  background: #fff;
+  color: #263238;
+  text-align: left;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
+.layer-group-header:hover {
+  background: #f8fafc;
+}
+
+.layer-group-header:focus-visible,
+.layer-name:focus-visible,
+.layer-zoom:focus-visible,
+.layer-options-icon:focus-visible {
+  outline: 2px solid #1976d2;
+  outline-offset: 2px;
+}
+
+.layer-group-title {
+  display: block;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.layer-group-description {
+  display: block;
+  margin-top: 3px;
+  color: #607d8b;
+  font-size: 12px;
+  line-height: 1.25;
+}
+
+.layer-group-arrow {
+  flex: 0 0 auto;
+  color: #1976d2;
+  transition: transform 160ms ease;
+}
+
+.layer-group-header[aria-expanded="true"] .layer-group-arrow,
+.layer-group:has(.layer-group-content.in) > .layer-group-header .layer-group-arrow {
+  transform: rotate(180deg);
+}
+
+.layer-group-content > .panel-body {
+  padding: 0;
+  background: #fff;
+}
+
+.layer-group-content .layer-group {
+  margin: 10px;
+  border: 0;
+  border-radius: 5px;
+  box-shadow: none;
+}
+
+.layer-group-content .layer-group .layer-group-header {
+  padding: 10px 12px;
+  border-radius: 5px;
+  border-bottom: 0;
+  background: linear-gradient(135deg, #0d47a1 0%, #1976d2 100%);
+  color: #fff;
+  box-shadow: 0 2px 5px rgba(13, 71, 161, 0.24);
+}
+
+.layer-group-content .layer-group .layer-group-description,
+.layer-group-content .layer-group .layer-group-arrow {
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.layer-row {
+  position: relative;
+  display: grid !important;
+  grid-template-columns: 32px minmax(0, 1fr) 34px;
+  align-items: center;
+  min-height: 42px;
+  padding: 7px 8px 7px 10px !important;
+  border: 0;
+  border-bottom: 1px solid #e5e7eb;
+  background: #fff !important;
+  transition: background-color 160ms ease;
+}
+
+.layer-row:hover {
+  background: #f1f5f9 !important;
+}
+
+.layer-row.layer-active,
+.layer-row.active {
+  background: #eef6ff !important;
+}
+
+.layer-row.layer-active::before,
+.layer-row.active::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  background: #1976d2;
+}
+
+.layer-legend {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  min-width: 32px;
+  padding: 0;
+}
+
+.layer-legend .legend-img {
+  max-width: 24px;
+  max-height: 24px;
+  object-fit: contain;
+}
+
+.layer-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  width: 100%;
+  padding: 0 8px;
+  border: 0;
+  background: transparent;
+  color: #263238;
+  font-size: 13px;
+  line-height: 1.25;
+  text-align: left;
+  cursor: pointer;
+}
+
+.layer-name span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.layer-row.layer-active .layer-name,
+.layer-row.active .layer-name {
+  font-weight: 700;
+  color: #263238 !important;
+}
+
+.layer-visibility-indicator {
+  display: none;
+  flex: 0 0 8px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #1976d2;
+}
+
+.layer-row.layer-active .layer-visibility-indicator,
+.layer-row.active .layer-visibility-indicator {
+  display: inline-block;
+}
+
+.layer-zoom,
+.layer-options-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: #1976d2;
+  cursor: pointer;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
+.layer-zoom:hover,
+.layer-options-icon:hover {
+  background: #e3f2fd;
+  color: #0d47a1;
+  opacity: 1;
+}
+
+.layer-row-with-options {
+  grid-template-columns: 32px minmax(0, 1fr) 34px 34px;
+}
+
+@media (min-width: 768px) {
+  .map-container #mapa {
+    margin-left: clamp(320px, 25vw, 380px);
+    width: calc(100% - clamp(320px, 25vw, 380px));
+  }
+}
+
+@media (max-width: 767px) {
+  #sidebar-container {
+    max-width: 90vw;
+    width: 90vw;
+    height: calc(100vh - 50px);
+  }
+
+  .layer-row,
+  .layer-row-with-options {
+    grid-template-columns: 32px minmax(0, 1fr) 34px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Modernizar la apariencia del panel lateral de capas para mostrar grupos colapsables, subencabezados y filas de capa con leyenda, nombre y botón de zoom siguiendo el diseño solicitado.
- Mantener intacta la lógica de activación/desactivación/consulta/zoom existente y añadir solo handlers y URLs necesarias para mostrar leyendas WMS y controlar la interacción del UI.

### Description
- Reemplazo de la generación HTML de grupos y capas: `ImpresorGrupoHTML` y `ImpresorItemHTML` ahora crean encabezados accesibles (`button`, `aria-expanded`, `aria-controls`) y filas con estructura de 3 columnas (leyenda, nombre, zoom). Archivos modificados: `src/js/entities.js`, `index.html`, `src/js/utils/functions/functions.js`, y nuevo CSS `src/styles/css/layer-panel.css`.
- Leyendas WMS dinámicas: añadidas las funciones `buildLayerLegendUrl(layer, fallbackLegend)`, `getGeoserverWorkspace(url, layerName)` y `ensureSecureLegendUrl(url)` para construir `GetLegendGraphic` usando el `host` configurado y evitar mixed content (HTTP → HTTPS); se conserva fallback a imágenes locales/error cuando corresponde.
- Accesibilidad y comportamiento UI: los controles interactivos de capas y zoom se crearon como `button`, se añadieron `aria-label` y tooltips, indicador visual de visibilidad y la clase visual `layer-active` cuando la capa está activa; se creó `escapeHtmlAttribute` para sanear descripciones en atributos.
- Handlers y robustez: `bindZoomLayer` y `bindLayerOptions` en `src/js/utils/functions/functions.js` ahora usan `event.preventDefault()` y `event.stopPropagation()` para evitar que el clic en la lupa active/desactive la capa, y usan marcas `dataset` para evitar bindings duplicados.
- Estilos dedicados: nuevo `src/styles/css/layer-panel.css` con reglas responsive, encabezados blancos con borde inferior, subgrupos con fondo degradado azul, filas en CSS Grid (`grid-template-columns: 32px minmax(0, 1fr) 34px`), leyendas con `max 24x24px`, estado activo con margen izquierdo azul y focus-visible claro; incluido en `index.html`.

### Testing
- `node --check src/js/entities.js` — OK (sintaxis válida).
- `node --check src/js/utils/functions/functions.js` — OK (sintaxis válida).
- `git diff --check` — OK (sin errores de diff/check detectados).
- Servido localmente y comprobado HTML: arrancado `python3 -m http.server 8765` y `curl -I http://127.0.0.1:8765/index.html` devolvió 200 OK.
- Nota: no se ejecutaron pruebas de interfaz en navegador (no hay Chromium/Chrome disponible en el entorno), por lo que no se verificó la consola del navegador ni comportamientos CSS avanzados en navegadores antiguos; la lógica del mapa/GeoServer/GetFeatureInfo no fue modificada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42861bf0a0832a914cbd169716ab9c)